### PR TITLE
Fix issue #8 by using six.stringtypes instead of basestring

### DIFF
--- a/redgreenunittest/case.py
+++ b/redgreenunittest/case.py
@@ -7,6 +7,7 @@ import difflib
 import pprint
 import re
 import warnings
+import six
 
 from . import result
 from .util import (
@@ -121,7 +122,7 @@ class _AssertRaisesContext(object):
             return True
 
         expected_regexp = self.expected_regexp
-        if isinstance(expected_regexp, basestring):
+        if isinstance(expected_regexp, six.string_types):
             expected_regexp = re.compile(expected_regexp)
         if not expected_regexp.search(str(exc_value)):
             raise self.failureException('"%s" does not match "%s"' %
@@ -901,9 +902,9 @@ class TestCase(object):
 
     def assertMultiLineEqual(self, first, second, msg=None):
         """Assert that two multi-line strings are equal."""
-        self.assertIsInstance(first, basestring,
+        self.assertIsInstance(first, six.string_types,
                 'First argument is not a string')
-        self.assertIsInstance(second, basestring,
+        self.assertIsInstance(second, six.string_types,
                 'Second argument is not a string')
 
         if first != second:
@@ -991,7 +992,7 @@ class TestCase(object):
 
     def assertRegexpMatches(self, text, expected_regexp, msg=None):
         """Fail the test unless the text matches the regular expression."""
-        if isinstance(expected_regexp, basestring):
+        if isinstance(expected_regexp, six.string_types):
             expected_regexp = re.compile(expected_regexp)
         if not expected_regexp.search(text):
             msg = msg or "Regexp didn't match"
@@ -1000,7 +1001,7 @@ class TestCase(object):
 
     def assertNotRegexpMatches(self, text, unexpected_regexp, msg=None):
         """Fail the test if the text matches the regular expression."""
-        if isinstance(unexpected_regexp, basestring):
+        if isinstance(unexpected_regexp, six.string_types):
             unexpected_regexp = re.compile(unexpected_regexp)
         match = unexpected_regexp.search(text)
         if match:

--- a/redgreenunittest/main.py
+++ b/redgreenunittest/main.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import sys
 import os
 import types
+import six
 
 from . import loader, runner
 from .signals import installHandler
@@ -75,7 +76,7 @@ class TestProgram(object):
                     testRunner=None, testLoader=loader.defaultTestLoader,
                     exit=True, verbosity=1, failfast=None, catchbreak=None,
                     buffer=None):
-        if isinstance(module, basestring):
+        if isinstance(module, six.string_types):
             self.module = __import__(module)
             for part in module.split('.')[1:]:
                 self.module = getattr(self.module, part)

--- a/redgreenunittest/suite.py
+++ b/redgreenunittest/suite.py
@@ -1,6 +1,7 @@
 """TestSuite"""
 
 import sys
+import six
 
 from . import case
 from . import util
@@ -55,7 +56,7 @@ class BaseTestSuite(object):
 
     def addTests(self, tests):
         try:
-            if isinstance(tests, basestring): # Python 2
+            if isinstance(tests, six.string_types): # Python 2
                 raise TypeError("tests must be an iterable of tests, not a string")
         except NameError:
             if isinstance(tests, str): # Python 3

--- a/redgreenunittest/test/test_case.py
+++ b/redgreenunittest/test/test_case.py
@@ -2,6 +2,7 @@ import difflib
 import pprint
 import re
 import sys
+import six
 
 from copy import deepcopy
 
@@ -368,7 +369,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             def runTest(self):
                 pass
 
-        self.assertIsInstance(Foo().id(), basestring)
+        self.assertIsInstance(Foo().id(), six.string_types)
 
     # "If result is omitted or None, a temporary result object is created
     # and used, but is not made available to the caller. As TestCase owns the

--- a/redgreenunittest/test/test_functiontestcase.py
+++ b/redgreenunittest/test/test_functiontestcase.py
@@ -1,4 +1,5 @@
 import redgreenunittest as unittest
+import six
 
 from .support import LoggingResult
 
@@ -124,7 +125,7 @@ class Test_FunctionTestCase(unittest.TestCase):
     def test_id(self):
         test = unittest.FunctionTestCase(lambda: None)
 
-        self.assertIsInstance(test.id(), basestring)
+        self.assertIsInstance(test.id(), six.string_types)
 
     # "Returns a one-line description of the test, or None if no description
     # has been provided. The default implementation of this method returns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pygments==1.6
 wsgiref==0.1.2
+six


### PR DESCRIPTION
Here is a simple fix for issue #8 to be able to use redgreenunittests for both python 2 and 3. It adds the six dependency to requirements.txt.